### PR TITLE
Fixed URL for speakers photos

### DIFF
--- a/perf-perfview-monitoring/src/sdpapp.shared/ConferenceService.cs
+++ b/perf-perfview-monitoring/src/sdpapp.shared/ConferenceService.cs
@@ -12,7 +12,7 @@ namespace SDPApp.Shared
     {
         const string SPEAKERS_URL = "http://www.seladeveloperpractice.com/api/speakers";
         const string SESSIONS_URL = "http://www.seladeveloperpractice.com/api/sessions";
-        const string CDN_BASE_URL = "http://sdp2.blob.core.windows.net";
+        const string CDN_BASE_URL = "http://sdp3.blob.core.windows.net";
 
         private static Dictionary<string, Speaker> _speakers;
         private static Dictionary<string, Session> _sessions;


### PR DESCRIPTION
The URL pointed to sdp2.blob.core.windows.net, but this address no longer exists. It should be sdp3.blob.core.windows.net