### PR TITLE
Fix Windows 10 SDK URL

### DIFF
--- a/prerequisites.md
+++ b/prerequisites.md
@@ -7,7 +7,7 @@ Before you start working on the labs, make sure you performed all the configurat
 You will need the following software to work on these hands-on labs:
 
 * Windows 8 or newer 64-bit operating system
-* [Windows 10 SDK](https://dev.windows.com/en-us/downloads/windows-10-sdk)
+* [Windows 10 SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk)
 * [Visual Studio 2015](https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs.aspx)
 * [PerfView 1.7](http://www.microsoft.com/en-us/download/details.aspx?id=28567)
 * [DebugDiag 2.0](http://www.microsoft.com/en-us/download/details.aspx?id=42933)


### PR DESCRIPTION
The old URL just redirects to https://developer.microsoft.com/en-us/